### PR TITLE
Feature/fix damon home

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -319,6 +319,7 @@ body {
   display: flex;
   flex-direction: column;
   padding: 16px;
+  margin-bottom: 16px;
   background: #ffffff;
   border-radius: 20px;
   box-sizing: border-box;

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -199,62 +199,6 @@ body {
   border-radius: 50%;
   background: #44cd45;
 }
-.ranking {
-  display: flex;
-  flex-direction: column;
-  padding: 16px;
-}
-.ranking .titleBlock {
-  padding: 0 0 16px 0;
-  line-height: 28px;
-  font-weight: bold;
-  font-size: 24px;
-  color: #070721;
-  text-transform: capitalize;
-}
-.ranking .selectContainer {
-  display: flex;
-  justify-content: space-around;
-  margin: 8px 0;
-}
-.ranking .chart {
-  display: none;
-}
-.ranking .chart.active {
-  display: block;
-}
-.ranking .chart .metric {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 10px;
-  font-size: 15px;
-  text-align: left;
-  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.2);
-  color: white;
-  background-color: lightblue;
-  background: linear-gradient(141deg, #3162ff 0%, #3162ff 51%, #2cb5e8 75%);
-  border-radius: 20px;
-  box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.175);
-}
-.ranking .chart .theOne {
-  background: linear-gradient(141deg, #edaef9 0%, #81b1fa 74%, #2cb5e8 85%);
-}
-.ranking .chart .metric-value {
-  font-weight: bold;
-}
-.ranking .chart-horizontal {
-  width: 100%;
-}
-.ranking .chart-horizontal .metric {
-  margin-bottom: 3px;
-  min-width: 100px;
-  padding: 6px 15px;
-}
-.ranking .chart-horizontal .metric-value {
-  float: right;
-  font-weight: bold;
-}
 .potentialConnectionsBlock {
   display: flex;
   flex-direction: column;
@@ -322,4 +266,97 @@ body {
   color: white;
   border-radius: 12px;
   background-color: #3162ff;
+}
+.authorCard {
+  padding: 0 16px 32px;
+  background-color: #ffff;
+  border-radius: 0 16px;
+}
+.authorCard .avatarContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 16px;
+}
+.authorCard .avatarContainer .avatar {
+  height: 56px;
+  border-radius: 8px;
+}
+.authorCard .avatarContainer .authorName {
+  padding-top: 16px;
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 21px;
+  color: #070721;
+  text-transform: capitalize;
+}
+.authorCard .infos {
+  color: #8e8c99;
+}
+.authorCard .infos .infosItem {
+  margin-bottom: 16px;
+}
+.authorCard .infos .bold {
+  font-weight: 700;
+}
+.authorCard .infos .keywordsItem {
+  margin: 4px 8px;
+  font-size: 14px;
+  list-style: none;
+}
+.ranking {
+  display: flex;
+  flex-direction: column;
+  padding: 16px;
+}
+.ranking .titleBlock {
+  padding: 0 0 16px 0;
+  line-height: 28px;
+  font-weight: bold;
+  font-size: 24px;
+  color: #070721;
+  text-transform: capitalize;
+}
+.ranking .selectContainer {
+  display: flex;
+  justify-content: space-around;
+  margin: 8px 0;
+}
+.ranking .chart {
+  display: none;
+}
+.ranking .chart.active {
+  display: block;
+}
+.ranking .chart .metric {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px;
+  font-size: 15px;
+  text-align: left;
+  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.2);
+  color: white;
+  background-color: lightblue;
+  background: linear-gradient(141deg, #3162ff 0%, #3162ff 51%, #2cb5e8 75%);
+  border-radius: 20px;
+  box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.175);
+}
+.ranking .chart .theOne {
+  background: linear-gradient(141deg, #edaef9 0%, #81b1fa 74%, #2cb5e8 85%);
+}
+.ranking .chart .metric-value {
+  font-weight: bold;
+}
+.ranking .chart-horizontal {
+  width: 100%;
+}
+.ranking .chart-horizontal .metric {
+  margin-bottom: 3px;
+  min-width: 100px;
+  padding: 6px 15px;
+}
+.ranking .chart-horizontal .metric-value {
+  float: right;
+  font-weight: bold;
 }

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -36,6 +36,15 @@ body {
   padding: 8px 0;
   font-size: 24px;
 }
+.mainWrapper .main .secondContent {
+  margin-top: 16px;
+}
+.mainWrapper .main .secondContent section {
+  width: calc(50% - 8px);
+}
+.mainWrapper .main .secondContent section:first-child {
+  margin-right: 16px;
+}
 .mainWrapper .side {
   width: 336px;
   padding-left: 16px;
@@ -134,6 +143,7 @@ body {
   margin: 0 0 16px;
   background: #ffffff;
   border-radius: 20px;
+  box-sizing: border-box;
 }
 .connectionsBlock .titleBlock {
   display: flex;
@@ -206,6 +216,7 @@ body {
   margin: 0 0 16px;
   background: #ffffff;
   border-radius: 20px;
+  box-sizing: border-box;
 }
 .potentialConnectionsBlock .titleBlock {
   display: flex;
@@ -308,6 +319,9 @@ body {
   display: flex;
   flex-direction: column;
   padding: 16px;
+  background: #ffffff;
+  border-radius: 20px;
+  box-sizing: border-box;
 }
 .ranking .titleBlock {
   padding: 0 0 16px 0;
@@ -359,4 +373,25 @@ body {
 .ranking .chart-horizontal .metric-value {
   float: right;
   font-weight: bold;
+}
+.chatsBlock {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: 16px;
+  margin: 0 0 16px;
+  background: #ffffff;
+  border-radius: 20px;
+  box-sizing: border-box;
+}
+.chatsBlock .titleBlock {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 0 0 16px 0;
+  line-height: 28px;
+  font-weight: bold;
+  font-size: 22px;
+  color: #070721;
+  text-transform: capitalize;
 }

--- a/assets/css/keyword.css
+++ b/assets/css/keyword.css
@@ -36,6 +36,15 @@ body {
   padding: 8px 0;
   font-size: 24px;
 }
+.mainWrapper .main .secondContent {
+  margin-top: 16px;
+}
+.mainWrapper .main .secondContent section {
+  width: calc(50% - 8px);
+}
+.mainWrapper .main .secondContent section:first-child {
+  margin-right: 16px;
+}
 .mainWrapper .side {
   width: 336px;
   padding-left: 16px;
@@ -134,6 +143,7 @@ body {
   margin: 0 0 16px;
   background: #ffffff;
   border-radius: 20px;
+  box-sizing: border-box;
 }
 .connectionsBlock .titleBlock {
   display: flex;
@@ -206,6 +216,7 @@ body {
   margin: 0 0 16px;
   background: #ffffff;
   border-radius: 20px;
+  box-sizing: border-box;
 }
 .potentialConnectionsBlock .titleBlock {
   display: flex;

--- a/assets/css/people.css
+++ b/assets/css/people.css
@@ -36,6 +36,15 @@ body {
   padding: 8px 0;
   font-size: 24px;
 }
+.mainWrapper .main .secondContent {
+  margin-top: 16px;
+}
+.mainWrapper .main .secondContent section {
+  width: calc(50% - 8px);
+}
+.mainWrapper .main .secondContent section:first-child {
+  margin-right: 16px;
+}
 .mainWrapper .side {
   width: 336px;
   padding-left: 16px;
@@ -134,6 +143,7 @@ body {
   margin: 0 0 16px;
   background: #ffffff;
   border-radius: 20px;
+  box-sizing: border-box;
 }
 .connectionsBlock .titleBlock {
   display: flex;
@@ -206,6 +216,7 @@ body {
   margin: 0 0 16px;
   background: #ffffff;
   border-radius: 20px;
+  box-sizing: border-box;
 }
 .potentialConnectionsBlock .titleBlock {
   display: flex;

--- a/assets/less/pages/common/_connections-block.less
+++ b/assets/less/pages/common/_connections-block.less
@@ -5,6 +5,7 @@
     margin: 0 0 16px;
     background: #ffffff;
     border-radius: 20px;
+    box-sizing: border-box;
 
     .titleBlock {
         display: flex;

--- a/assets/less/pages/common/_layout.less
+++ b/assets/less/pages/common/_layout.less
@@ -18,6 +18,18 @@ body {
             padding: 8px 0;
             font-size: 24px;
         }
+
+        .secondContent {
+            margin-top: 16px;
+
+            section {
+                width: calc(50% - 8px);
+
+                &:first-child {
+                    margin-right: 16px;
+                }
+            }
+        }
     }
 
     .side {

--- a/assets/less/pages/common/_potential-connections.less
+++ b/assets/less/pages/common/_potential-connections.less
@@ -5,6 +5,7 @@
     margin: 0 0 16px;
     background: #ffffff;
     border-radius: 20px;
+    box-sizing: border-box;
 
     .titleBlock {
         display: flex;

--- a/assets/less/pages/home/home.less
+++ b/assets/less/pages/home/home.less
@@ -5,3 +5,4 @@
 @import "../common/_potential-connections";
 @import "home/_authorCard";
 @import "home/_ranking";
+@import "home/_chats";

--- a/assets/less/pages/home/home.less
+++ b/assets/less/pages/home/home.less
@@ -2,5 +2,6 @@
 @import "../common/_layout";
 @import "../common/_header";
 @import "../common/_connections-block";
-@import "home/_ranking";
 @import "../common/_potential-connections";
+@import "home/_authorCard";
+@import "home/_ranking";

--- a/assets/less/pages/home/home/_authorCard.less
+++ b/assets/less/pages/home/home/_authorCard.less
@@ -1,0 +1,44 @@
+.authorCard {
+    padding: 0 16px 32px;
+    background-color: #ffff;
+    border-radius: 0 16px;
+
+    .avatarContainer {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 16px;
+
+        .avatar {
+            height: 56px;
+            border-radius: 8px;
+        }
+
+        .authorName {
+            padding-top: 16px;
+            font-weight: bold;
+            font-size: 18px;
+            line-height: 21px;
+            color: #070721;
+            text-transform: capitalize;
+        }
+    }
+
+    .infos {
+        color: #8e8c99;
+
+        .infosItem {
+            margin-bottom: 16px;
+        }
+
+        .bold {
+            font-weight: 700;
+        }
+
+        .keywordsItem {
+            margin: 4px 8px;
+            font-size: 14px;
+            list-style: none;
+        }
+    }
+}

--- a/assets/less/pages/home/home/_chats.less
+++ b/assets/less/pages/home/home/_chats.less
@@ -1,0 +1,22 @@
+.chatsBlock {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    padding: 16px;
+    margin: 0 0 16px;
+    background: #ffffff;
+    border-radius: 20px;
+    box-sizing: border-box;
+
+    .titleBlock {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        padding: 0 0 16px 0;
+        line-height: 28px;
+        font-weight: bold;
+        font-size: 22px;
+        color: #070721;
+        text-transform: capitalize;
+    }
+}

--- a/assets/less/pages/home/home/_ranking.less
+++ b/assets/less/pages/home/home/_ranking.less
@@ -2,6 +2,7 @@
     display: flex;
     flex-direction: column;    
     padding: 16px;
+    margin-bottom: 16px;
     background: #ffffff;
     border-radius: 20px;
     box-sizing: border-box;

--- a/assets/less/pages/home/home/_ranking.less
+++ b/assets/less/pages/home/home/_ranking.less
@@ -2,6 +2,9 @@
     display: flex;
     flex-direction: column;    
     padding: 16px;
+    background: #ffffff;
+    border-radius: 20px;
+    box-sizing: border-box;
 
     .titleBlock {
         padding: 0 0 16px 0;

--- a/dev-css/home.css
+++ b/dev-css/home.css
@@ -63,24 +63,6 @@ main{
   position: relative;
 }
 
-/* First Line */
-.firstLine {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-/* Second Line */
-.secondLine {
-  position: relative;
-}
-
-@media(max-width: 600px) {
-  .secondLine {
-    height: 96px;
-  }
-}
-
 /* Choice Container */
 .choiceContainer {
   position: relative;
@@ -113,13 +95,6 @@ main{
 
 .choiceContainer .bubbleContainer.pub {
   border-radius: 40px 0px 0px 40px;
-}
-
-.choiceContainer .bubbleContainer.all, .choiceContainer .titleAll {
-  width: 0;
-  height: 0;
-  font-size: 0;
-  border: 0;
 }
 
 .choiceContainer .bubbleContainer.active {

--- a/dev-css/home.css
+++ b/dev-css/home.css
@@ -31,10 +31,6 @@ main{
   align-items: center;
 }
 
-section {
-  margin: 16px 0 0;
-}
-
 .hide{
   display: none;
 }
@@ -388,14 +384,6 @@ section {
   margin: 0 9px;
 }
 
-.chatContainer, .ranking{
-  width: calc(100% - 20px);
-  margin: 16px 8px 0;
-  background: white;
-  border-radius: 20px;
-  box-sizing: border-box;
-}
-
 .left article h2{
   text-align: center;
 }
@@ -405,11 +393,6 @@ section {
   position: absolute;
   right: 5px;
 }
-
-/* ranking */
-
-
-
 
 @media screen and (min-width: 1024px) {
 

--- a/dev-css/home.css
+++ b/dev-css/home.css
@@ -16,16 +16,6 @@ h2 {
   text-transform: capitalize;
 }
 
-h3 {
-  padding-top: 9px;
-  font-weight: bold;
-  font-size: 18px;
-  line-height: 21px;
-  text-decoration-line: underline;
-  color: #070721;
-  text-transform: capitalize;
-}
-
 h4 {
   font-weight: bold;
   font-size: 15px;

--- a/dev-html/home.html
+++ b/dev-html/home.html
@@ -1062,33 +1062,64 @@
                     </div>
                   </section>
                 </section>
-              <article>
-          <!-- Chats -->
-          <section class="chatContainer">
-            <h2>Chats</h2>
-            <div class="messageContainer">
-              <div class="avatarContainer">
-                <img class="avatar" src="../img/avatar1.png" alt="avatar">
-              </div>
-              <div class="txtInfos">
-                <h4>Name name2</h4>
-                <span> je suis un message</span>
-              </div>
-              <div>
-                <img src="../img/messages.png" class="messages" alt="">
-              </div>
-            </div>
-            <div class="messageContainer">
-              <div class="avatarContainer">
-                <img class="avatar" src="../img/avatar1.png" alt="avatar">
-              </div>
-              <div class="txtInfos">
-                <h4>Name name2</h4>
-                <span> je suis un message</span>
-              </div>
-              <img src="../img/messages.png" class="messages" alt="">
-            </div>
-          </section>
+              <article class="secondContent">
+          
+              <!-- Connections -->
+              <section class="connectionsBlock">
+                <h2 class="titleBlock">Connections <span class="viewAll">view all</span></h2>
+                <div class="connectionsList">
+                  <div class="connectionWrapper">
+                    <div class="avatarContainer">
+                      <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                    </div>
+                      <div class="txtInfos">
+                        <h4 class="name">Annie Patel</h4>
+                        <p class="mainField"><span>Main field: </span>Computer Science</p>
+                      </div>
+                      <span class="time"> 15m ago</span>
+                  </div>
+                  <div class="connectionWrapper">
+                    <div class="avatarContainer">
+                      <img class="avatar" src="../img/avatar12.jpg" alt="avatar">
+                    </div>
+                      <div class="txtInfos">
+                        <h4 class="name">Annie Patel</h4>
+                        <p class="mainField"><span>Main field: </span>Computer Science</p>
+                      </div>
+                      <span class="time"> 15m ago</span>
+                  </div>
+                  <div class="connectionWrapper">
+                    <div class="avatarContainer">
+                      <img class="avatar" src="../img/avatar6.png" alt="avatar">
+                    </div>
+                      <div class="txtInfos">
+                        <h4 class="name">Annie Patel</h4>
+                        <p class="mainField"><span>Main field: </span>Computer Science</p>
+                      </div>
+                      <span class="time"> 15m ago</span>
+                  </div>
+                  <div class="connectionWrapper">
+                    <div class="avatarContainer">
+                      <img class="avatar" src="../img/avatar7.png" alt="avatar">
+                    </div>
+                      <div class="txtInfos">
+                        <h4 class="name">Annie Patel</h4>
+                        <p class="mainField"><span>Main field: </span>Computer Science</p>
+                      </div>
+                      <span class="time"> 15m ago</span>
+                  </div>
+                  <div class="connectionWrapper">
+                    <div class="avatarContainer">
+                      <img class="avatar" src="../img/avatar8.png" alt="avatar">
+                    </div>
+                      <div class="txtInfos">
+                        <h4 class="name">Annie Patel</h4>
+                        <p class="mainField"><span>Main field: </span>Computer Science</p>
+                      </div>
+                      <span class="time"> 15m ago</span>
+                  </div>
+                </div>
+              </section>
 
         <!-- Block My Ranking -->
         <section class="ranking">
@@ -1209,60 +1240,30 @@
       </article>
 
       <aside class="side">
-        <!-- Connections -->
-        <section class="connectionsBlock">
-          <h2 class="titleBlock">Connections <span class="viewAll">view all</span></h2>
-          <div class="connectionsList">
-            <div class="connectionWrapper">
-              <div class="avatarContainer">
-                <img class="avatar" src="../img/avatar1.png" alt="avatar">
-              </div>
-                <div class="txtInfos">
-                  <h4 class="name">Annie Patel</h4>
-                  <p class="mainField"><span>Main field: </span>Computer Science</p>
-                </div>
-                <span class="time"> 15m ago</span>
+        <!-- Chats -->
+        <section class="chatsBlock chatContainer">
+          <h2 class="titleBlock">Chats</h2>
+          <div class="messageContainer">
+            <div class="avatarContainer">
+              <img class="avatar" src="../img/avatar1.png" alt="avatar">
             </div>
-            <div class="connectionWrapper">
-              <div class="avatarContainer">
-                <img class="avatar" src="../img/avatar12.jpg" alt="avatar">
-              </div>
-                <div class="txtInfos">
-                  <h4 class="name">Annie Patel</h4>
-                  <p class="mainField"><span>Main field: </span>Computer Science</p>
-                </div>
-                <span class="time"> 15m ago</span>
+            <div class="txtInfos">
+              <h4>Name name2</h4>
+              <span> je suis un message</span>
             </div>
-            <div class="connectionWrapper">
-              <div class="avatarContainer">
-                <img class="avatar" src="../img/avatar6.png" alt="avatar">
-              </div>
-                <div class="txtInfos">
-                  <h4 class="name">Annie Patel</h4>
-                  <p class="mainField"><span>Main field: </span>Computer Science</p>
-                </div>
-                <span class="time"> 15m ago</span>
+            <div>
+              <img src="../img/messages.png" class="messages" alt="">
             </div>
-            <div class="connectionWrapper">
-              <div class="avatarContainer">
-                <img class="avatar" src="../img/avatar7.png" alt="avatar">
-              </div>
-                <div class="txtInfos">
-                  <h4 class="name">Annie Patel</h4>
-                  <p class="mainField"><span>Main field: </span>Computer Science</p>
-                </div>
-                <span class="time"> 15m ago</span>
+          </div>
+          <div class="messageContainer">
+            <div class="avatarContainer">
+              <img class="avatar" src="../img/avatar1.png" alt="avatar">
             </div>
-            <div class="connectionWrapper">
-              <div class="avatarContainer">
-                <img class="avatar" src="../img/avatar8.png" alt="avatar">
-              </div>
-                <div class="txtInfos">
-                  <h4 class="name">Annie Patel</h4>
-                  <p class="mainField"><span>Main field: </span>Computer Science</p>
-                </div>
-                <span class="time"> 15m ago</span>
+            <div class="txtInfos">
+              <h4>Name name2</h4>
+              <span> je suis un message</span>
             </div>
+            <img src="../img/messages.png" class="messages" alt="">
           </div>
         </section>
 

--- a/dev-html/home.html
+++ b/dev-html/home.html
@@ -115,100 +115,113 @@
                       <a class="cta" href="document.html" target="_blank" >open the link</a>
                     </div>
                   </div>
-                  <div class="infoContainer">
+                  <div class="authorCard">
                     <div class="avatarContainer">
                       <img class="avatar" src="https://sil.asc.upenn.edu/img/exchange/avatar/sandra-gonzalez-bailon.jpg" alt="avatar">
-                      <h3>Sandra González-Bailón</h3>
+                      <h3 class="authorName">Sandra González-Bailón</h3>
+                    </div>  
+                    <div class="infos">
+                        <p class="infosItem">
+                          <span class="bold">Title:</span> 
+                          Alexandra Heyman Nash Penn Integrates Knowledge 
+                        </p>
+                        <p class="infosItem">
+                          <span class="bold">Affiliation:</span>
+                          Annenberg School for Communication
+                        </p>
+                        <div class="infosItem">
+                          <p class="infosItem bold">Keywords:</p>
+                          <ul> 
+                            <li class="keywordsItem">Behavioral Change</li>
+                            <li class="keywordsItem">Social Cognition</li>
+                            <li class="keywordsItem">Communication</li>
+                            <li class="keywordsItem">Psychology</li>
+                            <li class="keywordsItem">Social Cognition</li>
+                            <li class="keywordsItem">Behavioral Change</li>
+                            <li class="keywordsItem">Communication</li> 
+                          </ul>
+                        </div>
+                    </div>
+                  </div>
+                  <img src="../img/book.png" alt="" class="bubble pub">
+                </div>
+
+                <div class="cardContainer pub" data-content-year="2021">
+                  <div class="backgroundIframe">
+                    <div class="iframeContainer openModal">
+                      <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/10/1026.png);"/></div>
+                      <a class="cta" href="document.html" target="_blank" >open the link</a>
+                    </div>
+                  </div>
+
+                  <div class="authorCard">
+                    <div class="avatarContainer">
+                      <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                      <h3 class="authorName">Name</h3>
                     </div>  
                       <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                           <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li> 
-                            </ul>
-                          </div>
+                        <p class="infosItem">
+                          <span class="bold"> Title:</span> 
+                          Alexandra Heyman Nash Penn Integrates Knowledge 
+                        </p>
+                        <p class="infosItem">
+                          <span class="bold">Affiliation:</span>
+                          Annenberg School for Communication
+                        </p>
+                        <div class="infosItem">
+                          <p class="bold infosItem">Keywords:</p>
+                          <ul> 
+                            <li class="keywordsItem">Behavioral Change</li>
+                            <li class="keywordsItem">Social Cognition</li>
+                            <li class="keywordsItem">Communication</li>
+                            <li class="keywordsItem">Psychology</li>
+                            <li class="keywordsItem">Social Cognition</li>
+                            <li class="keywordsItem">Behavioral Change</li>
+                            <li class="keywordsItem">Communication</li>
+                          </ul>
+                        </div>
+                      </div>
+                  </div>
+                  <img src="../img/book.png" alt="" class="bubble pub">
+              </div>
+                <div class="cardContainer pub" data-content-year="2021">
+                  <div class="backgroundIframe">
+                    <div class="iframeContainer openModal">
+                      <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/10/1026.png);"/></div>
+                      <a class="cta" href="document.html" target="_blank" >open the link</a>
+                    </div>
+                  </div>
+
+                  <div class="authorCard">
+                    <div class="avatarContainer">
+                      <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                      <h3 class="authorName">Name</h3>
+                    </div>  
+                      <div class="infos">
+                        <p class="infosItem">
+                          <span class="bold"> Title:</span> 
+                          Alexandra Heyman Nash Penn Integrates Knowledge 
+                        </p>
+                        <p class="infosItem">
+                          <span class="bold">Affiliation:</span>
+                          Annenberg School for Communication
+                        </p>
+                        <div class="infosItem">
+                          <p class="bold infosItem">Keywords:</p>
+                          <ul> 
+                            <li class="keywordsItem">Behavioral Change</li>
+                            <li class="keywordsItem">Social Cognition</li>
+                            <li class="keywordsItem">Communication</li>
+                            <li class="keywordsItem">Psychology</li>
+                            <li class="keywordsItem">Social Cognition</li>
+                            <li class="keywordsItem">Behavioral Change</li>
+                            <li class="keywordsItem">Communication</li>
+                          </ul>
+                        </div>
                       </div>
                   </div>
                   <img src="../img/book.png" alt="" class="bubble pub">
                 </div>
-                <div class="cardContainer pub" data-content-year="2021">
-                  <div class="backgroundIframe">
-                    <div class="iframeContainer openModal">
-                      <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/10/1026.png);"/></div>
-                      <a class="cta" href="document.html" target="_blank" >open the link</a>
-                    </div>
-                  </div>
-
-                    <div class="infoContainer">
-                      <div class="avatarContainer">
-                        <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                        <h3>Name</h3>
-                      </div>  
-                        <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
-                          </div>
-                        </div>
-                    </div>
-                    <img src="../img/book.png" alt="" class="bubble pub">
-                </div>
-                <div class="cardContainer pub" data-content-year="2021">
-                  <div class="backgroundIframe">
-                    <div class="iframeContainer openModal">
-                      <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/10/1026.png);"/></div>
-                      <a class="cta" href="document.html" target="_blank" >open the link</a>
-                    </div>
-                  </div>
-
-                    <div class="infoContainer">
-                      <div class="avatarContainer">
-                        <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                        <h3>Name</h3>
-                      </div>  
-                        <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
-                          </div>
-                        </div>
-                    </div>
-                    <img src="../img/book.png" alt="" class="bubble pub">
-                </div>
                 <div class="cardContainer pub" data-content-year="2020">
                   <div class="backgroundIframe">
                     <div class="iframeContainer openModal">
@@ -217,99 +230,111 @@
                     </div>
                   </div>
 
-                    <div class="infoContainer">
-                      <div class="avatarContainer">
-                        <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                        <h3>Name</h3>
-                      </div>  
-                        <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
-                          </div>
+                  <div class="authorCard">
+                    <div class="avatarContainer">
+                      <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                      <h3 class="authorName">Name</h3>
+                    </div>  
+                      <div class="infos">
+                        <p class="infosItem">
+                          <span class="bold"> Title:</span> 
+                          Alexandra Heyman Nash Penn Integrates Knowledge 
+                        </p>
+                        <p class="infosItem">
+                          <span class="bold">Affiliation:</span>
+                          Annenberg School for Communication
+                        </p>
+                        <div class="infosItem">
+                          <p class="bold infosItem">Keywords:</p>
+                          <ul> 
+                            <li class="keywordsItem">Behavioral Change</li>
+                            <li class="keywordsItem">Social Cognition</li>
+                            <li class="keywordsItem">Communication</li>
+                            <li class="keywordsItem">Psychology</li>
+                            <li class="keywordsItem">Social Cognition</li>
+                            <li class="keywordsItem">Behavioral Change</li>
+                            <li class="keywordsItem">Communication</li>
+                          </ul>
                         </div>
-                    </div>
-                    <img src="../img/book.png" alt="" class="bubble pub">
+                      </div>
+                  </div>
+                  <img src="../img/book.png" alt="" class="bubble pub">
+              </div>
+              <div class="cardContainer pub" data-content-year="2020">
+                <div class="backgroundIframe">
+                  <div class="iframeContainer openModal">
+                    <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/10/1026.png);"/></div>
+                    <a class="cta" href="document.html" target="_blank" >open the link</a>
+                  </div>
                 </div>
-                <div class="cardContainer pub" data-content-year="2020">
-                  <div class="backgroundIframe">
-                    <div class="iframeContainer openModal">
-                      <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/10/1026.png);"/></div>
-                      <a class="cta" href="document.html" target="_blank" >open the link</a>
+
+                <div class="authorCard">
+                  <div class="avatarContainer">
+                    <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                    <h3 class="authorName">Name</h3>
+                  </div>  
+                    <div class="infos">
+                      <p class="infosItem">
+                        <span class="bold"> Title:</span> 
+                        Alexandra Heyman Nash Penn Integrates Knowledge 
+                      </p>
+                      <p class="infosItem">
+                        <span class="bold">Affiliation:</span>
+                        Annenberg School for Communication
+                      </p>
+                      <div class="infosItem">
+                        <p class="bold infosItem">Keywords:</p>
+                        <ul> 
+                          <li class="keywordsItem">Behavioral Change</li>
+                          <li class="keywordsItem">Social Cognition</li>
+                          <li class="keywordsItem">Communication</li>
+                          <li class="keywordsItem">Psychology</li>
+                          <li class="keywordsItem">Social Cognition</li>
+                          <li class="keywordsItem">Behavioral Change</li>
+                          <li class="keywordsItem">Communication</li>
+                        </ul>
+                      </div>
+                    </div>
+                </div>
+                <img src="../img/book.png" alt="" class="bubble pub">
+              </div>
+              <div class="cardContainer pub" data-content-year="2013">
+                <div class="backgroundIframe">
+                  <div class="iframeContainer openModal">
+                    <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/10/1026.png);"/></div>
+                    <a class="cta" href="document.html" target="_blank" >open the link</a>
+                  </div>
+                </div>
+
+                <div class="authorCard">
+                  <div class="avatarContainer">
+                    <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                    <h3 class="authorName">Name</h3>
+                  </div>  
+                    <div class="infos">
+                      <p class="infosItem">
+                        <span class="bold"> Title:</span> 
+                        Alexandra Heyman Nash Penn Integrates Knowledge 
+                      </p>
+                      <p class="infosItem">
+                        <span class="bold">Affiliation:</span>
+                        Annenberg School for Communication
+                      </p>
+                      <div class="infosItem">
+                        <p class="bold infosItem">Keywords:</p>
+                        <ul> 
+                          <li class="keywordsItem">Behavioral Change</li>
+                          <li class="keywordsItem">Social Cognition</li>
+                          <li class="keywordsItem">Communication</li>
+                          <li class="keywordsItem">Psychology</li>
+                          <li class="keywordsItem">Social Cognition</li>
+                          <li class="keywordsItem">Behavioral Change</li>
+                          <li class="keywordsItem">Communication</li>
+                        </ul>
+                      </div>
                     </div>
                   </div>
-
-                    <div class="infoContainer">
-                      <div class="avatarContainer">
-                        <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                        <h3>Name</h3>
-                      </div>  
-                        <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
-                          </div>
-                        </div>
-                    </div>
-                    <img src="../img/book.png" alt="" class="bubble pub">
-                </div>
-                <div class="cardContainer pub" data-content-year="2013">
-                  <div class="backgroundIframe">
-                    <div class="iframeContainer openModal">
-                      <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/10/1026.png);"/></div>
-                      <a class="cta" href="document.html" target="_blank" >open the link</a>
-                    </div>
-                  </div>
-
-                    <div class="infoContainer">
-                      <div class="avatarContainer">
-                        <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                        <h3>Name</h3>
-                      </div>  
-                        <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
-                          </div>
-                        </div>
-                    </div>
-                    <img src="../img/book.png" alt="" class="bubble pub">
+                  <img src="../img/book.png" alt="" class="bubble pub">
                 </div>
               </div>
             </section>
@@ -342,29 +367,33 @@
                     </div>
                   </div>
 
-                    <div class="infoContainer">
-                      <div class="avatarContainer">
-                        <img class="avatar" src="https://sil.asc.upenn.edu/img/exchange/avatar/sandra-gonzalez-bailon.jpg" alt="avatar">
-                        <h3>Sandra González-Bailón</h3>
-                      </div>  
-                        <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
-                          </div>
+                  <div class="authorCard">
+                    <div class="avatarContainer">
+                      <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                      <h3 class="authorName">Name</h3>
+                    </div>  
+                      <div class="infos">
+                        <p class="infosItem">
+                          <span class="bold"> Title:</span> 
+                          Alexandra Heyman Nash Penn Integrates Knowledge 
+                        </p>
+                        <p class="infosItem">
+                          <span class="bold">Affiliation:</span>
+                          Annenberg School for Communication
+                        </p>
+                        <div class="infosItem">
+                          <p class="bold infosItem">Keywords:</p>
+                          <ul> 
+                            <li class="keywordsItem">Behavioral Change</li>
+                            <li class="keywordsItem">Social Cognition</li>
+                            <li class="keywordsItem">Communication</li>
+                            <li class="keywordsItem">Psychology</li>
+                            <li class="keywordsItem">Social Cognition</li>
+                            <li class="keywordsItem">Behavioral Change</li>
+                            <li class="keywordsItem">Communication</li>
+                          </ul>
                         </div>
+                      </div>
                     </div>
                     <img src="../img/youtube.png" alt="" class="bubble talk" style="width: 22px;">
                 </div>
@@ -376,31 +405,35 @@
                     </div>
                   </div>
 
-                    <div class="infoContainer">
-                      <div class="avatarContainer">
-                        <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                        <h3>Name</h3>
-                      </div>  
-                        <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
-                          </div>
+                  <div class="authorCard">
+                    <div class="avatarContainer">
+                      <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                      <h3 class="authorName">Name</h3>
+                    </div>  
+                      <div class="infos">
+                        <p class="infosItem">
+                          <span class="bold"> Title:</span> 
+                          Alexandra Heyman Nash Penn Integrates Knowledge 
+                        </p>
+                        <p class="infosItem">
+                          <span class="bold">Affiliation:</span>
+                          Annenberg School for Communication
+                        </p>
+                        <div class="infosItem">
+                          <p class="bold infosItem">Keywords:</p>
+                          <ul> 
+                            <li class="keywordsItem">Behavioral Change</li>
+                            <li class="keywordsItem">Social Cognition</li>
+                            <li class="keywordsItem">Communication</li>
+                            <li class="keywordsItem">Psychology</li>
+                            <li class="keywordsItem">Social Cognition</li>
+                            <li class="keywordsItem">Behavioral Change</li>
+                            <li class="keywordsItem">Communication</li>
+                          </ul>
                         </div>
-                    </div>
-                    <img src="../img/youtube.png" alt="" class="bubble talk" style="width: 22px;">
+                      </div>
+                  </div>
+                  <img src="../img/youtube.png" alt="" class="bubble talk" style="width: 22px;">
                 </div>
                 <div class="cardContainer talk" data-content-year="2013">
                   <div class="backgroundIframe">
@@ -409,143 +442,158 @@
                       <p class="Cta openModal">open the link</p>
                     </div>
                   </div>
-
-                    <div class="infoContainer">
-                      <div class="avatarContainer">
-                        <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                        <h3>Name</h3>
-                      </div>  
-                        <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
-                          </div>
+                  <div class="authorCard">
+                    <div class="avatarContainer">
+                      <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                      <h3 class="authorName">Name</h3>
+                    </div>  
+                      <div class="infos">
+                        <p class="infosItem">
+                          <span class="bold"> Title:</span> 
+                          Alexandra Heyman Nash Penn Integrates Knowledge 
+                        </p>
+                        <p class="infosItem">
+                          <span class="bold">Affiliation:</span>
+                          Annenberg School for Communication
+                        </p>
+                        <div class="infosItem">
+                          <p class="bold infosItem">Keywords:</p>
+                          <ul> 
+                            <li class="keywordsItem">Behavioral Change</li>
+                            <li class="keywordsItem">Social Cognition</li>
+                            <li class="keywordsItem">Communication</li>
+                            <li class="keywordsItem">Psychology</li>
+                            <li class="keywordsItem">Social Cognition</li>
+                            <li class="keywordsItem">Behavioral Change</li>
+                            <li class="keywordsItem">Communication</li>
+                          </ul>
                         </div>
+                      </div>
                     </div>
                     <img src="../img/youtube.png" alt="" class="bubble talk" style="width: 22px;">
-                </div>
-                <div class="cardContainer talk" data-content-year="2013">
-                  <div class="backgroundIframe">
-                    <div class="iframeContainer">
-                      <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/11/1187.jpg);"/></div>
-                      <p class="Cta openModal">open the link</p>
-                    </div>
                   </div>
+                  <div class="cardContainer talk" data-content-year="2013">
+                    <div class="backgroundIframe">
+                      <div class="iframeContainer">
+                        <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/11/1187.jpg);"/></div>
+                        <p class="Cta openModal">open the link</p>
+                      </div>
+                    </div>
 
-                    <div class="infoContainer">
+                    <div class="authorCard">
                       <div class="avatarContainer">
                         <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                        <h3>Name</h3>
+                        <h3 class="authorName">Name</h3>
                       </div>  
                         <div class="infos">
-                          <p>
+                          <p class="infosItem">
                             <span class="bold"> Title:</span> 
                             Alexandra Heyman Nash Penn Integrates Knowledge 
                           </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
-                          </div>
-                        </div>
-                    </div>
-                    <img src="../img/youtube.png" alt="" class="bubble talk" style="width: 22px;">
-                </div>
-                <div class="cardContainer talk" data-content-year="2013">
-                  <div class="backgroundIframe">
-                    <div class="iframeContainer">
-                      <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/11/1187.jpg);"/></div>
-                      <p class="Cta openModal">open the link</p>
-                    </div>
-                  </div>
-
-                    <div class="infoContainer">
-                      <div class="avatarContainer">
-                        <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                        <h3>Name</h3>
-                      </div>  
-                        <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
+                          <p class="infosItem">
+                            <span class="bold">Affiliation:</span>
+                            Annenberg School for Communication
                           </p>
-                          <div>
-                            <p class="bold">Keyword</p>
+                          <div class="infosItem">
+                            <p class="bold infosItem">Keywords:</p>
                             <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
+                              <li class="keywordsItem">Behavioral Change</li>
+                              <li class="keywordsItem">Social Cognition</li>
+                              <li class="keywordsItem">Communication</li>
+                              <li class="keywordsItem">Psychology</li>
+                              <li class="keywordsItem">Social Cognition</li>
+                              <li class="keywordsItem">Behavioral Change</li>
+                              <li class="keywordsItem">Communication</li>
                             </ul>
                           </div>
                         </div>
+                      </div>
+                      <img src="../img/youtube.png" alt="" class="bubble talk" style="width: 22px;">
                     </div>
-                    <img src="../img/youtube.png" alt="" class="bubble talk" style="width: 22px;">
-                </div>
-                <div class="cardContainer talk" data-content-year="1990">
-                  <div class="backgroundIframe">
-                    <div class="iframeContainer">
-                      <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/11/1187.jpg);"/></div>
-                      <p class="Cta openModal">open the link</p>
-                    </div>
-                  </div>
+                    <div class="cardContainer talk" data-content-year="2013">
+                      <div class="backgroundIframe">
+                        <div class="iframeContainer">
+                          <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/11/1187.jpg);"/></div>
+                          <p class="Cta openModal">open the link</p>
+                        </div>
+                      </div>
 
-                    <div class="infoContainer">
-                      <div class="avatarContainer">
-                        <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                        <h3>Name</h3>
-                      </div>  
-                        <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
+                      <div class="authorCard">
+                        <div class="avatarContainer">
+                          <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                          <h3 class="authorName">Name</h3>
+                        </div>  
+                          <div class="infos">
+                            <p class="infosItem">
+                              <span class="bold"> Title:</span> 
+                              Alexandra Heyman Nash Penn Integrates Knowledge 
+                            </p>
+                            <p class="infosItem">
+                              <span class="bold">Affiliation:</span>
+                              Annenberg School for Communication
+                            </p>
+                            <div class="infosItem">
+                              <p class="bold infosItem">Keywords:</p>
+                              <ul> 
+                                <li class="keywordsItem">Behavioral Change</li>
+                                <li class="keywordsItem">Social Cognition</li>
+                                <li class="keywordsItem">Communication</li>
+                                <li class="keywordsItem">Psychology</li>
+                                <li class="keywordsItem">Social Cognition</li>
+                                <li class="keywordsItem">Behavioral Change</li>
+                                <li class="keywordsItem">Communication</li>
+                              </ul>
+                            </div>
                           </div>
                         </div>
+                      <img src="../img/youtube.png" alt="" class="bubble talk" style="width: 22px;">
                     </div>
-                    <img src="../img/youtube.png" alt="" class="bubble talk" style="width: 22px;">
-                </div>
-              </div>
-            </section>
-        </section>
-        <section class="newsfeed press">
-            <section class="slider">
-              <div class="arrow left"></div>
-              <div class="arrow right"></div>
-            <div class="slickContainer">
+                    <div class="cardContainer talk" data-content-year="1990">
+                      <div class="backgroundIframe">
+                        <div class="iframeContainer">
+                          <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/11/1187.jpg);"/></div>
+                          <p class="Cta openModal">open the link</p>
+                        </div>
+                      </div>
+
+                      <div class="authorCard">
+                        <div class="avatarContainer">
+                          <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                          <h3 class="authorName">Name</h3>
+                        </div>  
+                          <div class="infos">
+                            <p class="infosItem">
+                              <span class="bold"> Title:</span> 
+                              Alexandra Heyman Nash Penn Integrates Knowledge 
+                            </p>
+                            <p class="infosItem">
+                              <span class="bold">Affiliation:</span>
+                              Annenberg School for Communication
+                            </p>
+                            <div class="infosItem">
+                              <p class="bold infosItem">Keywords:</p>
+                              <ul> 
+                                <li class="keywordsItem">Behavioral Change</li>
+                                <li class="keywordsItem">Social Cognition</li>
+                                <li class="keywordsItem">Communication</li>
+                                <li class="keywordsItem">Psychology</li>
+                                <li class="keywordsItem">Social Cognition</li>
+                                <li class="keywordsItem">Behavioral Change</li>
+                                <li class="keywordsItem">Communication</li>
+                              </ul>
+                            </div>
+                          </div>
+                        </div>
+                        <img src="../img/youtube.png" alt="" class="bubble talk" style="width: 22px;">
+                      </div>
+                    </div>
+                  </section>
+              </section>
+              <section class="newsfeed press">
+                  <section class="slider">
+                    <div class="arrow left"></div>
+                    <div class="arrow right"></div>
+                    <div class="slickContainer">
                       <div class="cardContainer press" data-content-year="2018">
                         <div class="backgroundIframe">
                           <div class="iframeContainer openModal">
@@ -554,29 +602,33 @@
                           </div>
                         </div>
 
-                          <div class="infoContainer">
-                            <div class="avatarContainer">
-                              <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                              <h3>Name</h3>
-                            </div>  
-                              <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
-                          </div>
+                        <div class="authorCard">
+                          <div class="avatarContainer">
+                            <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                            <h3 class="authorName">Name</h3>
+                          </div>  
+                            <div class="infos">
+                              <p class="infosItem">
+                                <span class="bold"> Title:</span> 
+                                Alexandra Heyman Nash Penn Integrates Knowledge 
+                              </p>
+                              <p class="infosItem">
+                                <span class="bold">Affiliation:</span>
+                                Annenberg School for Communication
+                              </p>
+                              <div class="infosItem">
+                                <p class="bold infosItem">Keywords:</p>
+                                <ul> 
+                                  <li class="keywordsItem">Behavioral Change</li>
+                                  <li class="keywordsItem">Social Cognition</li>
+                                  <li class="keywordsItem">Communication</li>
+                                  <li class="keywordsItem">Psychology</li>
+                                  <li class="keywordsItem">Social Cognition</li>
+                                  <li class="keywordsItem">Behavioral Change</li>
+                                  <li class="keywordsItem">Communication</li>
+                                </ul>
                               </div>
+                            </div>
                           </div>
                           <img src="../img/press.png" alt="" class="bubble press">
                       </div>
@@ -588,29 +640,33 @@
                           </div>
                         </div>
 
-                          <div class="infoContainer">
-                            <div class="avatarContainer">
-                              <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                              <h3>Name</h3>
-                            </div>  
-                              <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
-                          </div>
+                        <div class="authorCard">
+                          <div class="avatarContainer">
+                            <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                            <h3 class="authorName">Name</h3>
+                          </div>  
+                            <div class="infos">
+                              <p class="infosItem">
+                                <span class="bold"> Title:</span> 
+                                Alexandra Heyman Nash Penn Integrates Knowledge 
+                              </p>
+                              <p class="infosItem">
+                                <span class="bold">Affiliation:</span>
+                                Annenberg School for Communication
+                              </p>
+                              <div class="infosItem">
+                                <p class="bold infosItem">Keywords:</p>
+                                <ul> 
+                                  <li class="keywordsItem">Behavioral Change</li>
+                                  <li class="keywordsItem">Social Cognition</li>
+                                  <li class="keywordsItem">Communication</li>
+                                  <li class="keywordsItem">Psychology</li>
+                                  <li class="keywordsItem">Social Cognition</li>
+                                  <li class="keywordsItem">Behavioral Change</li>
+                                  <li class="keywordsItem">Communication</li>
+                                </ul>
                               </div>
+                            </div>
                           </div>
                           <img src="../img/press.png" alt="" class="bubble press">
                       </div>
@@ -622,31 +678,348 @@
                           </div>
                         </div>
 
-                          <div class="infoContainer">
+                        <div class="authorCard">
+                          <div class="avatarContainer">
+                            <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                            <h3 class="authorName">Name</h3>
+                          </div>  
+                            <div class="infos">
+                              <p class="infosItem">
+                                <span class="bold"> Title:</span> 
+                                Alexandra Heyman Nash Penn Integrates Knowledge 
+                              </p>
+                              <p class="infosItem">
+                                <span class="bold">Affiliation:</span>
+                                Annenberg School for Communication
+                              </p>
+                              <div class="infosItem">
+                                <p class="bold infosItem">Keywords:</p>
+                                <ul> 
+                                  <li class="keywordsItem">Behavioral Change</li>
+                                  <li class="keywordsItem">Social Cognition</li>
+                                  <li class="keywordsItem">Communication</li>
+                                  <li class="keywordsItem">Psychology</li>
+                                  <li class="keywordsItem">Social Cognition</li>
+                                  <li class="keywordsItem">Behavioral Change</li>
+                                  <li class="keywordsItem">Communication</li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+                          <img src="../img/press.png" alt="" class="bubble press">
+                        </div>
+                        <div class="cardContainer press" data-content-year="2014">
+                          <div class="backgroundIframe">
+                            <div class="iframeContainer openModal">
+                              <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/6/681.png);"/></div>
+                              <a class="cta" href="document.html" target="_blank" >open the link</a>
+                            </div>
+                          </div>
+
+                          <div class="authorCard">
                             <div class="avatarContainer">
                               <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                              <h3>Name</h3>
+                              <h3 class="authorName">Name</h3>
                             </div>  
                               <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
-                          </div>
+                                <p class="infosItem">
+                                  <span class="bold"> Title:</span> 
+                                  Alexandra Heyman Nash Penn Integrates Knowledge 
+                                </p>
+                                <p class="infosItem">
+                                  <span class="bold">Affiliation:</span>
+                                  Annenberg School for Communication
+                                </p>
+                                <div class="infosItem">
+                                  <p class="bold infosItem">Keywords:</p>
+                                  <ul> 
+                                    <li class="keywordsItem">Behavioral Change</li>
+                                    <li class="keywordsItem">Social Cognition</li>
+                                    <li class="keywordsItem">Communication</li>
+                                    <li class="keywordsItem">Psychology</li>
+                                    <li class="keywordsItem">Social Cognition</li>
+                                    <li class="keywordsItem">Behavioral Change</li>
+                                    <li class="keywordsItem">Communication</li>
+                                  </ul>
+                                </div>
                               </div>
                           </div>
                           <img src="../img/press.png" alt="" class="bubble press">
+                        </div>
+                        <div class="cardContainer press" data-content-year="2013">
+                          <div class="backgroundIframe">
+                            <div class="iframeContainer openModal">
+                              <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/6/681.png);"/></div>
+                              <a class="cta" href="document.html" target="_blank" >open the link</a>
+                            </div>
+                          </div>
+
+                          <div class="authorCard">
+                            <div class="avatarContainer">
+                              <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                              <h3 class="authorName">Name</h3>
+                            </div>  
+                              <div class="infos">
+                                <p class="infosItem">
+                                  <span class="bold"> Title:</span> 
+                                  Alexandra Heyman Nash Penn Integrates Knowledge 
+                                </p>
+                                <p class="infosItem">
+                                  <span class="bold">Affiliation:</span>
+                                  Annenberg School for Communication
+                                </p>
+                                <div class="infosItem">
+                                  <p class="bold infosItem">Keywords:</p>
+                                  <ul> 
+                                    <li class="keywordsItem">Behavioral Change</li>
+                                    <li class="keywordsItem">Social Cognition</li>
+                                    <li class="keywordsItem">Communication</li>
+                                    <li class="keywordsItem">Psychology</li>
+                                    <li class="keywordsItem">Social Cognition</li>
+                                    <li class="keywordsItem">Behavioral Change</li>
+                                    <li class="keywordsItem">Communication</li>
+                                  </ul>
+                                </div>
+                              </div>
+                            </div>
+                            <img src="../img/press.png" alt="" class="bubble press">
+                        </div>
+                        <div class="cardContainer press" data-content-year="2011">
+                          <div class="backgroundIframe">
+                            <div class="iframeContainer openModal">
+                              <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/6/681.png);"/></div>
+                              <a class="cta" href="document.html" target="_blank" >open the link</a>
+                            </div>
+                          </div>
+
+                          <div class="authorCard">
+                            <div class="avatarContainer">
+                              <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                              <h3 class="authorName">Name</h3>
+                            </div>  
+                              <div class="infos">
+                                <p class="infosItem">
+                                  <span class="bold"> Title:</span> 
+                                  Alexandra Heyman Nash Penn Integrates Knowledge 
+                                </p>
+                                <p class="infosItem">
+                                  <span class="bold">Affiliation:</span>
+                                  Annenberg School for Communication
+                                </p>
+                                <div class="infosItem">
+                                  <p class="bold infosItem">Keywords:</p>
+                                  <ul> 
+                                    <li class="keywordsItem">Behavioral Change</li>
+                                    <li class="keywordsItem">Social Cognition</li>
+                                    <li class="keywordsItem">Communication</li>
+                                    <li class="keywordsItem">Psychology</li>
+                                    <li class="keywordsItem">Social Cognition</li>
+                                    <li class="keywordsItem">Behavioral Change</li>
+                                    <li class="keywordsItem">Communication</li>
+                                  </ul>
+                                </div>
+                              </div>
+                            </div>
+                            <img src="../img/press.png" alt="" class="bubble press">
+                        </div>
+                      </div>
+                    </section>
+                  </section>
+
+                  <section class="newsfeed all">
+                    <section class="slider">
+                      <div class="arrow left"></div>
+                      <div class="arrow right"></div>
+                      <div class="slickContainer">
+                        <div class="cardContainer pub" data-content-year="2022">
+                          <div class="backgroundIframe">
+                            <div class="iframeContainer openModal">
+                              <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/10/1026.png);"/></div>
+                              <a class="cta" href="document.html" target="_blank" >open the link</a>
+                            </div>
+                          </div>
+
+                          <div class="authorCard">
+                            <div class="avatarContainer">
+                              <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                              <h3 class="authorName">Name</h3>
+                            </div>  
+                              <div class="infos">
+                                <p class="infosItem">
+                                  <span class="bold"> Title:</span> 
+                                  Alexandra Heyman Nash Penn Integrates Knowledge 
+                                </p>
+                                <p class="infosItem">
+                                  <span class="bold">Affiliation:</span>
+                                  Annenberg School for Communication
+                                </p>
+                                <div class="infosItem">
+                                  <p class="bold infosItem">Keywords:</p>
+                                  <ul> 
+                                    <li class="keywordsItem">Behavioral Change</li>
+                                    <li class="keywordsItem">Social Cognition</li>
+                                    <li class="keywordsItem">Communication</li>
+                                    <li class="keywordsItem">Psychology</li>
+                                    <li class="keywordsItem">Social Cognition</li>
+                                    <li class="keywordsItem">Behavioral Change</li>
+                                    <li class="keywordsItem">Communication</li>
+                                  </ul>
+                                </div>
+                              </div>
+                            </div>
+                            <img src="../img/book.png" alt="" class="bubble pub">
+                          </div>
+                          <div class="cardContainer talk" data-content-year="2010">
+                            <div class="backgroundIframe">
+                              <div class="iframeContainer">
+                                <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/11/1187.jpg);"/></div>
+                                <p class="Cta openModal">open the link</p>
+                              </div>
+                            </div>
+
+                            <div class="authorCard">
+                              <div class="avatarContainer">
+                                <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                                <h3 class="authorName">Name</h3>
+                              </div>  
+                                <div class="infos">
+                                  <p class="infosItem">
+                                    <span class="bold"> Title:</span> 
+                                    Alexandra Heyman Nash Penn Integrates Knowledge 
+                                  </p>
+                                  <p class="infosItem">
+                                    <span class="bold">Affiliation:</span>
+                                    Annenberg School for Communication
+                                  </p>
+                                  <div class="infosItem">
+                                    <p class="bold infosItem">Keywords:</p>
+                                    <ul> 
+                                      <li class="keywordsItem">Behavioral Change</li>
+                                      <li class="keywordsItem">Social Cognition</li>
+                                      <li class="keywordsItem">Communication</li>
+                                      <li class="keywordsItem">Psychology</li>
+                                      <li class="keywordsItem">Social Cognition</li>
+                                      <li class="keywordsItem">Behavioral Change</li>
+                                      <li class="keywordsItem">Communication</li>
+                                    </ul>
+                                  </div>
+                                </div>
+                            </div>
+                            <img src="../img/youtube.png" alt="" class="bubble talk" style="width: 22px;">
+                          </div>
+                          <div class="cardContainer press" data-content-year="2020">
+                            <div class="backgroundIframe">
+                              <div class="iframeContainer openModal">
+                                <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/6/681.png);"/></div>
+                                <a class="cta" href="document.html" target="_blank" >open the link</a>
+                              </div>
+                            </div>
+
+                            <div class="authorCard">
+                              <div class="avatarContainer">
+                                <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                                <h3 class="authorName">Name</h3>
+                              </div>  
+                                <div class="infos">
+                                  <p class="infosItem">
+                                    <span class="bold"> Title:</span> 
+                                    Alexandra Heyman Nash Penn Integrates Knowledge 
+                                  </p>
+                                  <p class="infosItem">
+                                    <span class="bold">Affiliation:</span>
+                                    Annenberg School for Communication
+                                  </p>
+                                  <div class="infosItem">
+                                    <p class="bold infosItem">Keywords:</p>
+                                    <ul> 
+                                      <li class="keywordsItem">Behavioral Change</li>
+                                      <li class="keywordsItem">Social Cognition</li>
+                                      <li class="keywordsItem">Communication</li>
+                                      <li class="keywordsItem">Psychology</li>
+                                      <li class="keywordsItem">Social Cognition</li>
+                                      <li class="keywordsItem">Behavioral Change</li>
+                                      <li class="keywordsItem">Communication</li>
+                                    </ul>
+                                  </div>
+                                </div>
+                            </div>
+                            <img src="../img/press.png" alt="" class="bubble press">
+                          </div>
+                          <div class="cardContainer pub" data-content-year="2018">
+                            <div class="backgroundIframe">
+                              <div class="iframeContainer openModal">
+                                <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/10/1026.png);"/></div>
+                                <a class="cta" href="document.html" target="_blank" >open the link</a>
+                              </div>
+                            </div>
+
+                            <div class="authorCard">
+                              <div class="avatarContainer">
+                                <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                                <h3 class="authorName">Name</h3>
+                              </div>  
+                                <div class="infos">
+                                  <p class="infosItem">
+                                    <span class="bold"> Title:</span> 
+                                    Alexandra Heyman Nash Penn Integrates Knowledge 
+                                  </p>
+                                  <p class="infosItem">
+                                    <span class="bold">Affiliation:</span>
+                                    Annenberg School for Communication
+                                  </p>
+                                  <div class="infosItem">
+                                    <p class="bold infosItem">Keywords:</p>
+                                    <ul> 
+                                      <li class="keywordsItem">Behavioral Change</li>
+                                      <li class="keywordsItem">Social Cognition</li>
+                                      <li class="keywordsItem">Communication</li>
+                                      <li class="keywordsItem">Psychology</li>
+                                      <li class="keywordsItem">Social Cognition</li>
+                                      <li class="keywordsItem">Behavioral Change</li>
+                                      <li class="keywordsItem">Communication</li>
+                                    </ul>
+                                  </div>
+                                </div>
+                            </div>
+                            <img src="../img/book.png" alt="" class="bubble pub">
+                        </div>
+                        <div class="cardContainer talk" data-content-year="2015">
+                          <div class="backgroundIframe">
+                            <div class="iframeContainer">
+                              <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/11/1187.jpg);"/></div>
+                              <p class="Cta openModal">open the link</p>
+                            </div>
+                          </div>
+
+                          <div class="authorCard">
+                            <div class="avatarContainer">
+                              <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                              <h3 class="authorName">Name</h3>
+                            </div>  
+                              <div class="infos">
+                                <p class="infosItem">
+                                  <span class="bold"> Title:</span> 
+                                  Alexandra Heyman Nash Penn Integrates Knowledge 
+                                </p>
+                                <p class="infosItem">
+                                  <span class="bold">Affiliation:</span>
+                                  Annenberg School for Communication
+                                </p>
+                                <div class="infosItem">
+                                  <p class="bold infosItem">Keywords:</p>
+                                  <ul> 
+                                    <li class="keywordsItem">Behavioral Change</li>
+                                    <li class="keywordsItem">Social Cognition</li>
+                                    <li class="keywordsItem">Communication</li>
+                                    <li class="keywordsItem">Psychology</li>
+                                    <li class="keywordsItem">Social Cognition</li>
+                                    <li class="keywordsItem">Behavioral Change</li>
+                                    <li class="keywordsItem">Communication</li>
+                                  </ul>
+                                </div>
+                              </div>
+                          </div>
+                          <img src="../img/youtube.png" alt="" class="bubble talk" style="width: 22px;">
                       </div>
                       <div class="cardContainer press" data-content-year="2014">
                         <div class="backgroundIframe">
@@ -656,316 +1029,40 @@
                           </div>
                         </div>
 
-                          <div class="infoContainer">
-                            <div class="avatarContainer">
-                              <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                              <h3>Name</h3>
-                            </div>  
-                              <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
-                          </div>
+                        <div class="authorCard">
+                          <div class="avatarContainer">
+                            <img class="avatar" src="../img/avatar1.png" alt="avatar">
+                            <h3 class="authorName">Name</h3>
+                          </div>  
+                            <div class="infos">
+                              <p class="infosItem">
+                                <span class="bold"> Title:</span> 
+                                Alexandra Heyman Nash Penn Integrates Knowledge 
+                              </p>
+                              <p class="infosItem">
+                                <span class="bold">Affiliation:</span>
+                                Annenberg School for Communication
+                              </p>
+                              <div class="infosItem">
+                                <p class="bold infosItem">Keywords:</p>
+                                <ul> 
+                                  <li class="keywordsItem">Behavioral Change</li>
+                                  <li class="keywordsItem">Social Cognition</li>
+                                  <li class="keywordsItem">Communication</li>
+                                  <li class="keywordsItem">Psychology</li>
+                                  <li class="keywordsItem">Social Cognition</li>
+                                  <li class="keywordsItem">Behavioral Change</li>
+                                  <li class="keywordsItem">Communication</li>
+                                </ul>
                               </div>
-                          </div>
-                          <img src="../img/press.png" alt="" class="bubble press">
-                      </div>
-                      <div class="cardContainer press" data-content-year="2013">
-                        <div class="backgroundIframe">
-                          <div class="iframeContainer openModal">
-                            <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/6/681.png);"/></div>
-                            <a class="cta" href="document.html" target="_blank" >open the link</a>
-                          </div>
+                            </div>
                         </div>
-
-                          <div class="infoContainer">
-                            <div class="avatarContainer">
-                              <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                              <h3>Name</h3>
-                            </div>  
-                              <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
-                          </div>
-                              </div>
-                          </div>
-                          <img src="../img/press.png" alt="" class="bubble press">
-                      </div>
-                      <div class="cardContainer press" data-content-year="2011">
-                        <div class="backgroundIframe">
-                          <div class="iframeContainer openModal">
-                            <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/6/681.png);"/></div>
-                            <a class="cta" href="document.html" target="_blank" >open the link</a>
-                          </div>
-                        </div>
-
-                          <div class="infoContainer">
-                            <div class="avatarContainer">
-                              <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                              <h3>Name</h3>
-                            </div>  
-                              <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
-                          </div>
-                              </div>
-                          </div>
-                          <img src="../img/press.png" alt="" class="bubble press">
+                        <img src="../img/press.png" alt="" class="bubble press">
                       </div>
                     </div>
                   </section>
-        </section>
-
-        <section class="newsfeed all">
-            <section class="slider">
-              <div class="arrow left"></div>
-              <div class="arrow right"></div>
-              <div class="slickContainer">
-                <div class="cardContainer pub" data-content-year="2022">
-                  <div class="backgroundIframe">
-                    <div class="iframeContainer openModal">
-                      <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/10/1026.png);"/></div>
-                      <a class="cta" href="document.html" target="_blank" >open the link</a>
-                    </div>
-                  </div>
-
-                    <div class="infoContainer">
-                      <div class="avatarContainer">
-                        <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                        <h3>Name</h3>
-                      </div>  
-                        <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
-                          </div>
-                        </div>
-                        <img src="../img/book.png" alt="" class="bubble pub">
-                    </div>
-                    <div class="cardContainer talk" data-content-year="2010">
-                      <div class="backgroundIframe">
-                        <div class="iframeContainer">
-                          <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/11/1187.jpg);"/></div>
-                          <p class="Cta openModal">open the link</p>
-                        </div>
-                      </div>
-
-                    <div class="infoContainer">
-                      <div class="avatarContainer">
-                        <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                        <h3>Name</h3>
-                      </div>  
-                        <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
-                          </div>
-                        </div>
-                    </div>
-                    <img src="../img/youtube.png" alt="" class="bubble talk" style="width: 22px;">
-                </div>
-                <div class="cardContainer press" data-content-year="2020">
-                  <div class="backgroundIframe">
-                    <div class="iframeContainer openModal">
-                      <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/6/681.png);"/></div>
-                      <a class="cta" href="document.html" target="_blank" >open the link</a>
-                    </div>
-                  </div>
-
-                    <div class="infoContainer">
-                      <div class="avatarContainer">
-                        <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                        <h3>Name</h3>
-                      </div>  
-                        <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
-                          </div>
-                        </div>
-                    </div>
-                    <img src="../img/press.png" alt="" class="bubble press">
-                </div>
-                <div class="cardContainer pub" data-content-year="2018">
-                  <div class="backgroundIframe">
-                    <div class="iframeContainer openModal">
-                      <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/10/1026.png);"/></div>
-                      <a class="cta" href="document.html" target="_blank" >open the link</a>
-                    </div>
-                  </div>
-
-                    <div class="infoContainer">
-                      <div class="avatarContainer">
-                        <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                        <h3>Name</h3>
-                      </div>  
-                        <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
-                          </div>
-                        </div>
-                    </div>
-                    <img src="../img/book.png" alt="" class="bubble pub">
-                </div>
-                <div class="cardContainer talk" data-content-year="2015">
-                  <div class="backgroundIframe">
-                    <div class="iframeContainer">
-                      <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/11/1187.jpg);"/></div>
-                      <p class="Cta openModal">open the link</p>
-                    </div>
-                  </div>
-
-                    <div class="infoContainer">
-                      <div class="avatarContainer">
-                        <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                        <h3>Name</h3>
-                      </div>  
-                        <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
-                          </div>
-                        </div>
-                    </div>
-                    <img src="../img/youtube.png" alt="" class="bubble talk" style="width: 22px;">
-                </div>
-                <div class="cardContainer press" data-content-year="2014">
-                  <div class="backgroundIframe">
-                    <div class="iframeContainer openModal">
-                      <div class="newsFeedThumb" style="background-image: url(https://sil.asc.upenn.edu/exchange/thumbnails/6/681.png);"/></div>
-                      <a class="cta" href="document.html" target="_blank" >open the link</a>
-                    </div>
-                  </div>
-
-                    <div class="infoContainer">
-                      <div class="avatarContainer">
-                        <img class="avatar" src="../img/avatar1.png" alt="avatar">
-                        <h3>Name</h3>
-                      </div>  
-                        <div class="infos">
-                          <p>
-                            <span class="bold"> Title:</span> 
-                            Alexandra Heyman Nash Penn Integrates Knowledge 
-                          </p>
-                          <div>
-                            <p class="bold">Keyword</p>
-                            <ul> 
-                              <li>Behavioral Change</li>
-                              <li>Social Cognition</li>
-                              <li>Communication</li>
-                              <li>Psychology</li>
-                              <li>Social Cognition</li>
-                              <li>Behavioral Change</li>
-                              <li>Communication</li>
-                            </ul>
-                          </div>
-                        </div>
-                    </div>
-                    <img src="../img/press.png" alt="" class="bubble press">
-                </div>
-              </div>
-            </section>
-        </section>
-        <article>
+                </section>
+              <article>
           <!-- Chats -->
           <section class="chatContainer">
             <h2>Chats</h2>

--- a/dev-html/home.html
+++ b/dev-html/home.html
@@ -32,67 +32,61 @@
     <main class="mainWrapper">
       <article class="main">
 			  <div class="headerNewsFeed">
-			    <div class="firstLine">
-				    <h2>Your Media</h2>
-				    <span id="allFeed" class="all">see all</span>
-			    </div>
-          <div class="secondLine">
-            <div class="choiceContainer">
-              <div class="bubbleContainer pub active" data-category="pub">
-                <img src="../img/book.png" alt="papers">
-                <span>Papers</span>
-                <div class="time">
-                  <img src="../img/time.png" class="selectDate" alt="select date picto">
-                  <div class="list">
-                    <ul class="listDates">
-                      <!-- Completed by JS -->
-                    </ul>
-                  </div>
-                  <span class="selectedDate">2020</span>
+          <div class="choiceContainer">
+            <div class="bubbleContainer pub active" data-category="pub">
+              <img src="../img/book.png" alt="papers">
+              <span>Papers</span>
+              <div class="time">
+                <img src="../img/time.png" class="selectDate" alt="select date picto">
+                <div class="list">
+                  <ul class="listDates">
+                    <!-- Completed by JS -->
+                  </ul>
                 </div>
+                <span class="selectedDate">2020</span>
               </div>
-              <div class="bubbleContainer talk" data-category="talk">
-                <img src="../img/youtube.png" alt="talks">
-                <span>Talks</span>
-                <div class="time">
-                  <img src="../img/time.png" class="selectDate" alt="select date picto">
-                  <div class="list">
-                    <ul class="listDates">
-                      <!-- Completed by JS -->
-                    </ul>
-                  </div>
-                  <span class="selectedDate">2021</span>
-                </div>
-              </div>                    
-              <div class="bubbleContainer press" data-category="press">
-                <img src="../img/press.png" alt="press">
-                <span>Press</span>
-                <div class="time">
-                  <img src="../img/time.png" class="selectDate" alt="select date picto">
-                  <div class="list">
-                    <ul class="listDates">
-                      <!-- Completed by JS -->
-                    </ul>
-                  </div>
-                  <span class="selectedDate">2022</span>
-                </div>
-              </div>
-              <!-- Button for See All : hide but important for select Date -->
-              <div class="bubbleContainer all" data-category="all">
-                <span class="titleAll">All</span>
-                <div class="time">
-                  <img src="../img/time.png" class="selectDate" alt="select date picto">
-                  <div class="list">
-                    <ul class="listDates">
-                      <!-- Completed by JS -->
-                    </ul>
-                  </div>
-                  <span class="selectedDate">2023</span>
-                </div>
-                </div>
             </div>
+            <div class="bubbleContainer talk" data-category="talk">
+              <img src="../img/youtube.png" alt="talks">
+              <span>Talks</span>
+              <div class="time">
+                <img src="../img/time.png" class="selectDate" alt="select date picto">
+                <div class="list">
+                  <ul class="listDates">
+                    <!-- Completed by JS -->
+                  </ul>
+                </div>
+                <span class="selectedDate">2021</span>
+              </div>
+            </div>                    
+            <div class="bubbleContainer press" data-category="press">
+              <img src="../img/press.png" alt="press">
+              <span>Press</span>
+              <div class="time">
+                <img src="../img/time.png" class="selectDate" alt="select date picto">
+                <div class="list">
+                  <ul class="listDates">
+                    <!-- Completed by JS -->
+                  </ul>
+                </div>
+                <span class="selectedDate">2022</span>
+              </div>
+            </div>
+            <!-- Button for See All : hide but important for select Date -->
+            <div class="bubbleContainer all" data-category="all">
+              <span class="titleAll">All</span>
+              <div class="time">
+                <img src="../img/time.png" class="selectDate" alt="select date picto">
+                <div class="list">
+                  <ul class="listDates">
+                    <!-- Completed by JS -->
+                  </ul>
+                </div>
+                <span class="selectedDate">2023</span>
+              </div>
+              </div>
           </div>
-			</div>
+			  </div>
         <section class="newsfeed pub active">
             <section class="slider">
               <div class="arrow left"></div>
@@ -1418,10 +1412,10 @@
     /**************************
     /* Create Sliders NewsFeed
     ***************************/
-	function initSlick(category) {
+	  function initSlick(category) {
 
-        // Sliders feed
-        const buttonsOpanModal = document.querySelectorAll('.openModal');
+      // Sliders feed
+      const buttonsOpanModal = document.querySelectorAll('.openModal');
 
 	    $('.newsfeed.' + category + ' .slickContainer').slick({
         dots: false,
@@ -1484,7 +1478,7 @@
       // Add the date by default (first of the list)
       const firstDate = document.querySelector('.bubbleContainer.' + category + ' .time .selectedDate')
       firstDate.innerHTML = timeLineUniqueDates[0]
-	}
+	  }
 	  
     $(document).ready(function(){
       initSlick('pub');
@@ -1523,7 +1517,7 @@
 
       // Active news feed
       const choices = document.querySelectorAll('.bubbleContainer')
-      const allFeed = document.querySelector('#allFeed')
+      const allFeed = document.querySelector('.bubbleContainer.all')
       const selectsDateAll = document.querySelectorAll('.all .time')
 
       allFeed.addEventListener('click', function () {
@@ -1545,7 +1539,8 @@
           closeSelectDate()
           // Show the right carousel
           for (let choice of choices) {
-            choice.classList.remove('active')
+            if (!e.currentTarget.classList.contains('all'))
+              choice.classList.remove('active')
           }
           choice.classList.add('active')
 		      let category = choice.getAttribute('data-category')

--- a/dev-html/home.html
+++ b/dev-html/home.html
@@ -121,26 +121,30 @@
                       <h3 class="authorName">Sandra González-Bailón</h3>
                     </div>  
                     <div class="infos">
-                        <p class="infosItem">
-                          <span class="bold">Title:</span> 
-                          Alexandra Heyman Nash Penn Integrates Knowledge 
-                        </p>
-                        <p class="infosItem">
-                          <span class="bold">Affiliation:</span>
-                          Annenberg School for Communication
-                        </p>
-                        <div class="infosItem">
-                          <p class="infosItem bold">Keywords:</p>
-                          <ul> 
-                            <li class="keywordsItem">Behavioral Change</li>
-                            <li class="keywordsItem">Social Cognition</li>
-                            <li class="keywordsItem">Communication</li>
-                            <li class="keywordsItem">Psychology</li>
-                            <li class="keywordsItem">Social Cognition</li>
-                            <li class="keywordsItem">Behavioral Change</li>
-                            <li class="keywordsItem">Communication</li> 
-                          </ul>
-                        </div>
+                      <p class="infosItem">
+                        <span class="bold">Main Field:</span> 
+                        Social Psychology 
+                      </p>
+                      <p class="infosItem">
+                        <span class="bold">Title:</span> 
+                        Alexandra Heyman Nash Penn Integrates Knowledge 
+                      </p>
+                      <p class="infosItem">
+                        <span class="bold">Affiliation:</span>
+                        Annenberg School for Communication
+                      </p>
+                      <div class="infosItem">
+                        <p class="infosItem bold">Keywords:</p>
+                        <ul> 
+                          <li class="keywordsItem">Behavioral Change</li>
+                          <li class="keywordsItem">Social Cognition</li>
+                          <li class="keywordsItem">Communication</li>
+                          <li class="keywordsItem">Psychology</li>
+                          <li class="keywordsItem">Social Cognition</li>
+                          <li class="keywordsItem">Behavioral Change</li>
+                          <li class="keywordsItem">Communication</li> 
+                        </ul>
+                      </div>
                     </div>
                   </div>
                   <img src="../img/book.png" alt="" class="bubble pub">
@@ -159,7 +163,11 @@
                       <img class="avatar" src="../img/avatar1.png" alt="avatar">
                       <h3 class="authorName">Name</h3>
                     </div>  
-                      <div class="infos">
+                    <div class="infos">
+                      <p class="infosItem">
+                        <span class="bold">Main Field:</span> 
+                        Social Psychology 
+                      </p>
                         <p class="infosItem">
                           <span class="bold"> Title:</span> 
                           Alexandra Heyman Nash Penn Integrates Knowledge 
@@ -197,7 +205,11 @@
                       <img class="avatar" src="../img/avatar1.png" alt="avatar">
                       <h3 class="authorName">Name</h3>
                     </div>  
-                      <div class="infos">
+                    <div class="infos">
+                      <p class="infosItem">
+                        <span class="bold">Main Field:</span> 
+                        Social Psychology 
+                      </p>
                         <p class="infosItem">
                           <span class="bold"> Title:</span> 
                           Alexandra Heyman Nash Penn Integrates Knowledge 
@@ -235,7 +247,11 @@
                       <img class="avatar" src="../img/avatar1.png" alt="avatar">
                       <h3 class="authorName">Name</h3>
                     </div>  
-                      <div class="infos">
+                    <div class="infos">
+                      <p class="infosItem">
+                        <span class="bold">Main Field:</span> 
+                        Social Psychology 
+                      </p>
                         <p class="infosItem">
                           <span class="bold"> Title:</span> 
                           Alexandra Heyman Nash Penn Integrates Knowledge 
@@ -275,6 +291,10 @@
                   </div>  
                     <div class="infos">
                       <p class="infosItem">
+                        <span class="bold">Main Field:</span> 
+                        Social Psychology 
+                      </p>
+                      <p class="infosItem">
                         <span class="bold"> Title:</span> 
                         Alexandra Heyman Nash Penn Integrates Knowledge 
                       </p>
@@ -312,6 +332,10 @@
                     <h3 class="authorName">Name</h3>
                   </div>  
                     <div class="infos">
+                      <p class="infosItem">
+                        <span class="bold">Main Field:</span> 
+                        Social Psychology 
+                      </p>
                       <p class="infosItem">
                         <span class="bold"> Title:</span> 
                         Alexandra Heyman Nash Penn Integrates Knowledge 
@@ -372,7 +396,11 @@
                       <img class="avatar" src="../img/avatar1.png" alt="avatar">
                       <h3 class="authorName">Name</h3>
                     </div>  
-                      <div class="infos">
+                    <div class="infos">
+                      <p class="infosItem">
+                        <span class="bold">Main Field:</span> 
+                        Social Psychology 
+                      </p>
                         <p class="infosItem">
                           <span class="bold"> Title:</span> 
                           Alexandra Heyman Nash Penn Integrates Knowledge 
@@ -412,6 +440,10 @@
                     </div>  
                       <div class="infos">
                         <p class="infosItem">
+                          <span class="bold">Main Field:</span> 
+                          Social Psychology 
+                        </p>
+                        <p class="infosItem">
                           <span class="bold"> Title:</span> 
                           Alexandra Heyman Nash Penn Integrates Knowledge 
                         </p>
@@ -448,6 +480,10 @@
                       <h3 class="authorName">Name</h3>
                     </div>  
                       <div class="infos">
+                      <p class="infosItem">
+                        <span class="bold">Main Field:</span> 
+                        Social Psychology 
+                      </p>
                         <p class="infosItem">
                           <span class="bold"> Title:</span> 
                           Alexandra Heyman Nash Penn Integrates Knowledge 
@@ -485,7 +521,11 @@
                         <img class="avatar" src="../img/avatar1.png" alt="avatar">
                         <h3 class="authorName">Name</h3>
                       </div>  
-                        <div class="infos">
+                      <div class="infos">
+                        <p class="infosItem">
+                          <span class="bold">Main Field:</span> 
+                          Social Psychology 
+                        </p>
                           <p class="infosItem">
                             <span class="bold"> Title:</span> 
                             Alexandra Heyman Nash Penn Integrates Knowledge 
@@ -525,6 +565,10 @@
                         </div>  
                           <div class="infos">
                             <p class="infosItem">
+                              <span class="bold">Main Field:</span> 
+                              Social Psychology 
+                            </p>
+                            <p class="infosItem">
                               <span class="bold"> Title:</span> 
                               Alexandra Heyman Nash Penn Integrates Knowledge 
                             </p>
@@ -562,6 +606,10 @@
                           <h3 class="authorName">Name</h3>
                         </div>  
                           <div class="infos">
+                            <p class="infosItem">
+                              <span class="bold">Main Field:</span> 
+                              Social Psychology 
+                            </p>
                             <p class="infosItem">
                               <span class="bold"> Title:</span> 
                               Alexandra Heyman Nash Penn Integrates Knowledge 
@@ -607,7 +655,11 @@
                             <img class="avatar" src="../img/avatar1.png" alt="avatar">
                             <h3 class="authorName">Name</h3>
                           </div>  
-                            <div class="infos">
+                          <div class="infos">
+                            <p class="infosItem">
+                              <span class="bold">Main Field:</span> 
+                              Social Psychology 
+                            </p>
                               <p class="infosItem">
                                 <span class="bold"> Title:</span> 
                                 Alexandra Heyman Nash Penn Integrates Knowledge 
@@ -647,6 +699,10 @@
                           </div>  
                             <div class="infos">
                               <p class="infosItem">
+                                <span class="bold">Main Field:</span> 
+                                Social Psychology 
+                              </p>
+                              <p class="infosItem">
                                 <span class="bold"> Title:</span> 
                                 Alexandra Heyman Nash Penn Integrates Knowledge 
                               </p>
@@ -683,7 +739,11 @@
                             <img class="avatar" src="../img/avatar1.png" alt="avatar">
                             <h3 class="authorName">Name</h3>
                           </div>  
-                            <div class="infos">
+                          <div class="infos">
+                            <p class="infosItem">
+                              <span class="bold">Main Field:</span> 
+                              Social Psychology 
+                            </p>
                               <p class="infosItem">
                                 <span class="bold"> Title:</span> 
                                 Alexandra Heyman Nash Penn Integrates Knowledge 
@@ -721,28 +781,32 @@
                               <img class="avatar" src="../img/avatar1.png" alt="avatar">
                               <h3 class="authorName">Name</h3>
                             </div>  
-                              <div class="infos">
-                                <p class="infosItem">
-                                  <span class="bold"> Title:</span> 
-                                  Alexandra Heyman Nash Penn Integrates Knowledge 
-                                </p>
-                                <p class="infosItem">
-                                  <span class="bold">Affiliation:</span>
-                                  Annenberg School for Communication
-                                </p>
-                                <div class="infosItem">
-                                  <p class="bold infosItem">Keywords:</p>
-                                  <ul> 
-                                    <li class="keywordsItem">Behavioral Change</li>
-                                    <li class="keywordsItem">Social Cognition</li>
-                                    <li class="keywordsItem">Communication</li>
-                                    <li class="keywordsItem">Psychology</li>
-                                    <li class="keywordsItem">Social Cognition</li>
-                                    <li class="keywordsItem">Behavioral Change</li>
-                                    <li class="keywordsItem">Communication</li>
-                                  </ul>
-                                </div>
+                            <div class="infos">
+                              <p class="infosItem">
+                                <span class="bold">Main Field:</span> 
+                                Social Psychology 
+                              </p>
+                              <p class="infosItem">
+                                <span class="bold"> Title:</span> 
+                                Alexandra Heyman Nash Penn Integrates Knowledge 
+                              </p>
+                              <p class="infosItem">
+                                <span class="bold">Affiliation:</span>
+                                Annenberg School for Communication
+                              </p>
+                              <div class="infosItem">
+                                <p class="bold infosItem">Keywords:</p>
+                                <ul> 
+                                  <li class="keywordsItem">Behavioral Change</li>
+                                  <li class="keywordsItem">Social Cognition</li>
+                                  <li class="keywordsItem">Communication</li>
+                                  <li class="keywordsItem">Psychology</li>
+                                  <li class="keywordsItem">Social Cognition</li>
+                                  <li class="keywordsItem">Behavioral Change</li>
+                                  <li class="keywordsItem">Communication</li>
+                                </ul>
                               </div>
+                            </div>
                           </div>
                           <img src="../img/press.png" alt="" class="bubble press">
                         </div>
@@ -759,30 +823,34 @@
                               <img class="avatar" src="../img/avatar1.png" alt="avatar">
                               <h3 class="authorName">Name</h3>
                             </div>  
-                              <div class="infos">
-                                <p class="infosItem">
-                                  <span class="bold"> Title:</span> 
-                                  Alexandra Heyman Nash Penn Integrates Knowledge 
-                                </p>
-                                <p class="infosItem">
-                                  <span class="bold">Affiliation:</span>
-                                  Annenberg School for Communication
-                                </p>
-                                <div class="infosItem">
-                                  <p class="bold infosItem">Keywords:</p>
-                                  <ul> 
-                                    <li class="keywordsItem">Behavioral Change</li>
-                                    <li class="keywordsItem">Social Cognition</li>
-                                    <li class="keywordsItem">Communication</li>
-                                    <li class="keywordsItem">Psychology</li>
-                                    <li class="keywordsItem">Social Cognition</li>
-                                    <li class="keywordsItem">Behavioral Change</li>
-                                    <li class="keywordsItem">Communication</li>
-                                  </ul>
-                                </div>
+                            <div class="infos">
+                              <p class="infosItem">
+                                <span class="bold">Main Field:</span> 
+                                Social Psychology 
+                              </p>
+                              <p class="infosItem">
+                                <span class="bold"> Title:</span> 
+                                Alexandra Heyman Nash Penn Integrates Knowledge 
+                              </p>
+                              <p class="infosItem">
+                                <span class="bold">Affiliation:</span>
+                                Annenberg School for Communication
+                              </p>
+                              <div class="infosItem">
+                                <p class="bold infosItem">Keywords:</p>
+                                <ul> 
+                                  <li class="keywordsItem">Behavioral Change</li>
+                                  <li class="keywordsItem">Social Cognition</li>
+                                  <li class="keywordsItem">Communication</li>
+                                  <li class="keywordsItem">Psychology</li>
+                                  <li class="keywordsItem">Social Cognition</li>
+                                  <li class="keywordsItem">Behavioral Change</li>
+                                  <li class="keywordsItem">Communication</li>
+                                </ul>
                               </div>
                             </div>
-                            <img src="../img/press.png" alt="" class="bubble press">
+                          </div>
+                          <img src="../img/press.png" alt="" class="bubble press">
                         </div>
                         <div class="cardContainer press" data-content-year="2011">
                           <div class="backgroundIframe">
@@ -797,30 +865,34 @@
                               <img class="avatar" src="../img/avatar1.png" alt="avatar">
                               <h3 class="authorName">Name</h3>
                             </div>  
-                              <div class="infos">
-                                <p class="infosItem">
-                                  <span class="bold"> Title:</span> 
-                                  Alexandra Heyman Nash Penn Integrates Knowledge 
-                                </p>
-                                <p class="infosItem">
-                                  <span class="bold">Affiliation:</span>
-                                  Annenberg School for Communication
-                                </p>
-                                <div class="infosItem">
-                                  <p class="bold infosItem">Keywords:</p>
-                                  <ul> 
-                                    <li class="keywordsItem">Behavioral Change</li>
-                                    <li class="keywordsItem">Social Cognition</li>
-                                    <li class="keywordsItem">Communication</li>
-                                    <li class="keywordsItem">Psychology</li>
-                                    <li class="keywordsItem">Social Cognition</li>
-                                    <li class="keywordsItem">Behavioral Change</li>
-                                    <li class="keywordsItem">Communication</li>
-                                  </ul>
-                                </div>
+                            <div class="infos">
+                              <p class="infosItem">
+                                <span class="bold">Main Field:</span> 
+                                Social Psychology 
+                              </p>
+                              <p class="infosItem">
+                                <span class="bold"> Title:</span> 
+                                Alexandra Heyman Nash Penn Integrates Knowledge 
+                              </p>
+                              <p class="infosItem">
+                                <span class="bold">Affiliation:</span>
+                                Annenberg School for Communication
+                              </p>
+                              <div class="infosItem">
+                                <p class="bold infosItem">Keywords:</p>
+                                <ul> 
+                                  <li class="keywordsItem">Behavioral Change</li>
+                                  <li class="keywordsItem">Social Cognition</li>
+                                  <li class="keywordsItem">Communication</li>
+                                  <li class="keywordsItem">Psychology</li>
+                                  <li class="keywordsItem">Social Cognition</li>
+                                  <li class="keywordsItem">Behavioral Change</li>
+                                  <li class="keywordsItem">Communication</li>
+                                </ul>
                               </div>
                             </div>
-                            <img src="../img/press.png" alt="" class="bubble press">
+                          </div>
+                          <img src="../img/press.png" alt="" class="bubble press">
                         </div>
                       </div>
                     </section>
@@ -844,7 +916,11 @@
                               <img class="avatar" src="../img/avatar1.png" alt="avatar">
                               <h3 class="authorName">Name</h3>
                             </div>  
-                              <div class="infos">
+                            <div class="infos">
+                              <p class="infosItem">
+                                <span class="bold">Main Field:</span> 
+                                Social Psychology 
+                              </p>
                                 <p class="infosItem">
                                   <span class="bold"> Title:</span> 
                                   Alexandra Heyman Nash Penn Integrates Knowledge 
@@ -882,7 +958,11 @@
                                 <img class="avatar" src="../img/avatar1.png" alt="avatar">
                                 <h3 class="authorName">Name</h3>
                               </div>  
-                                <div class="infos">
+                              <div class="infos">
+                                <p class="infosItem">
+                                  <span class="bold">Main Field:</span> 
+                                  Social Psychology 
+                                </p>
                                   <p class="infosItem">
                                     <span class="bold"> Title:</span> 
                                     Alexandra Heyman Nash Penn Integrates Knowledge 
@@ -920,7 +1000,11 @@
                                 <img class="avatar" src="../img/avatar1.png" alt="avatar">
                                 <h3 class="authorName">Name</h3>
                               </div>  
-                                <div class="infos">
+                              <div class="infos">
+                                <p class="infosItem">
+                                  <span class="bold">Main Field:</span> 
+                                  Social Psychology 
+                                </p>
                                   <p class="infosItem">
                                     <span class="bold"> Title:</span> 
                                     Alexandra Heyman Nash Penn Integrates Knowledge 
@@ -958,7 +1042,11 @@
                                 <img class="avatar" src="../img/avatar1.png" alt="avatar">
                                 <h3 class="authorName">Name</h3>
                               </div>  
-                                <div class="infos">
+                              <div class="infos">
+                                <p class="infosItem">
+                                  <span class="bold">Main Field:</span> 
+                                  Social Psychology 
+                                </p>
                                   <p class="infosItem">
                                     <span class="bold"> Title:</span> 
                                     Alexandra Heyman Nash Penn Integrates Knowledge 
@@ -996,7 +1084,11 @@
                               <img class="avatar" src="../img/avatar1.png" alt="avatar">
                               <h3 class="authorName">Name</h3>
                             </div>  
-                              <div class="infos">
+                            <div class="infos">
+                              <p class="infosItem">
+                                <span class="bold">Main Field:</span> 
+                                Social Psychology 
+                              </p>
                                 <p class="infosItem">
                                   <span class="bold"> Title:</span> 
                                   Alexandra Heyman Nash Penn Integrates Knowledge 
@@ -1034,7 +1126,11 @@
                             <img class="avatar" src="../img/avatar1.png" alt="avatar">
                             <h3 class="authorName">Name</h3>
                           </div>  
-                            <div class="infos">
+                          <div class="infos">
+                            <p class="infosItem">
+                              <span class="bold">Main Field:</span> 
+                              Social Psychology 
+                            </p>
                               <p class="infosItem">
                                 <span class="bold"> Title:</span> 
                                 Alexandra Heyman Nash Penn Integrates Knowledge 


### PR DESCRIPTION
- [x] brief/efficient/uniformly sized author descriptions beneath content (example2), which include name, title, affiliation, and keywords, using the style/formatting (example 1 - particularly for font/color/size, etc.)
- [x] Perhaps we should include 'main field' in the author's info below the main content, as well.  Again, using the text style from (example 1)
- [x] exchange chat and potential connections  
- [ ] I like the cleanliness of the name, title, main field, affiliation, and then a simple blue 'follow' button.
- [x] We need to populate the 'search' space with the text "search people"
- [x] Remove 'See All' link at top of page.  
- [x] Headings for section areas are:  No Heading for main content area.  "Connections"  for peer list on right. "Potential Connections" for peer list on bottom left.  "My Rankings" for Rankings Area.  "Chats" for comment wall with peers, located below the "Connections" section  
- [x] In Ranking panel, for sub-heading elements in drop down list, these should match style of other panels on the page so they feel like sub-headings.  So, let's try the font/style/size of the faculty names in the 'Connections' panel, from ex 